### PR TITLE
Send signal to child process

### DIFF
--- a/src/tempwork/tempwork.go
+++ b/src/tempwork/tempwork.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/signal"
 	"sync"
 	"syscall"
 )
@@ -87,6 +88,16 @@ func Run(tw *Tempwork) (exitCode int, err error) {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
+
+	sig := make(chan os.Signal)
+	signal.Notify(sig)
+
+	go func() {
+		for {
+			s := <-sig
+			cmd.Process.Signal(s)
+		}
+	}()
 
 	go func() {
 		io.Copy(os.Stdout, outReader)


### PR DESCRIPTION
- Child proces become zombi process when `kill <tempwork process id>`
- Forward signal to child process
