### PR TITLE
Fix segv when commmand failed

### DIFF
--- a/tempwork.go
+++ b/tempwork.go
@@ -95,6 +95,10 @@ func Run(tw *Tempwork) (exitCode int, err error) {
 	go func() {
 		for {
 			s := <-sig
+
+			if cmd.Process == nil {
+				continue
+			}
 			cmd.Process.Signal(s)
 		}
 	}()


### PR DESCRIPTION
Sometime raise  error as follow in production envrionment.
I think that error raise when command failed.  🤔 
but, I haven't been able to reproduce it in my local environment.
This same error have not raise since this fix code. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x49c92b]

goroutine 17 [running]:
os.(*Process).signal(0x0, 0x50bd20, 0xc00001e050, 0x0, 0x0)
	/usr/lib/golang/src/os/exec_unix.go:56 +0x3b
os.(*Process).Signal(...)
	/usr/lib/golang/src/os/exec.go:131
tempwork.Run.func1(0xc00005a0c0, 0xc000076000)
	/root/rpmbuild/BUILD/src/tempwork.go:98 +0x66
created by tempwork.Run
	/root/rpmbuild/BUILD/src/tempwork.go:95 +0x1d6
```
